### PR TITLE
Update M2Crypto import and version

### DIFF
--- a/gentlsa.py
+++ b/gentlsa.py
@@ -14,7 +14,7 @@ import ssl
 import dns.resolver
 import smtplib
 import hashlib
-import M2Crypto
+import M2Crypto.X509
 
 try:
     import CloudFlare

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cloudflare==2.8.14
 docopt==0.6.2
-M2Crypto==0.37.1
+M2Crypto==0.41.0
 dnspython==2.0.0


### PR DESCRIPTION
The import statement in gentlsa.py has been updated to import the X509 submodule from M2Crypto instead of the whole library. Additionally, the version of the M2Crypto library listed in requirements.txt has also been updated to v0.41.0 from v0.37.1.